### PR TITLE
Deeper paths

### DIFF
--- a/bcompare-completions.sh
+++ b/bcompare-completions.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 # source this to setup completion for bcompare.
 
 complete -fd bcompare

--- a/goto-completions.sh
+++ b/goto-completions.sh
@@ -1,10 +1,11 @@
+#!/usr/bin/bash
 # source this to define the goto function and setup completion for it.
 
 goto() {
 
   # script to goto a specific repo.
   # v1 - only find with github.com root of node
-  local repo_root=${GOTO_REPO_ROOT:-$HOME/github.com}
+  local repo_root=${GOTO_ROOT:-$HOME/github.com}
 
   if [ -z "$1" ]; then
     echo "goto: nowhere to go"
@@ -13,9 +14,11 @@ goto() {
 
   if [ -d "$1" ]; then
     echo "goto: changing to $1"
+    # shellcheck disable=SC2164
     cd "$1"
   elif [ -d "$repo_root/$1" ]; then
     echo "goto: changing to $1"
+    # shellcheck disable=SC2164
     cd "$repo_root/$1"
   else
     echo "goto: $1 does not exist"
@@ -26,12 +29,13 @@ goto() {
 _goto_completions()
 {
   # for testing without invoking the goto function.
-  local simulated
+  local debugging
 
   # let this run interactively for testing
-  if [ "$COMP_WORDS" == "" ]; then
+  # shellcheck disable=SC2128
+  if [ -z "$COMP_WORDS" ]; then
     local name=$1
-    local simulated=true
+    local debugging=true
   elif [ "${#COMP_WORDS[@]}" != "2" ]; then
     return
   else
@@ -39,68 +43,79 @@ _goto_completions()
   fi
 
   # get the parts of the name
-  local IFS=$'/'
-  local name_parts=($(echo "$name"))
+  local name_parts
+  IFS='/' read -ra name_parts <<< "$name"
 
   # how many parts of the repo path did the user supply?
   local n=${#name_parts[@]}
+  [ -n "$debugging" ] && echo "[$n name_parts]"
 
   # the root repository to search. need a way to set this across repos
   # and maybe languages.
   local repo_root=${GOTO_REPO_ROOT:-$HOME/github.com}
 
+  local pattern
+  local pattern2
   # modify the pattern based on how specific the user was. if there is only
   # one item make pattern2 as it might represent the user, not the user's repo.
-  if [ $n -eq 1 ]; then
+  if [ "$n" -eq 1 ]; then
     # if the name ends in slash presume it's a user
     if [ "${name: -1}" = "/" ]; then
       local user_only=true
-      local pattern="$repo_root/${name%?}*"
+      pattern="$repo_root/${name%?}*"
     else
       local user_only=false
-      local pattern="$repo_root/*/$name*"
-      local pattern2="$repo_root/${name}*"
+      pattern="$repo_root/*/$name*"
+      pattern2="$repo_root/${name}*"
     fi
-  elif [ $n -eq 2 ]; then
-    local pattern="$repo_root/${name_parts[0]}*/${name_parts[1]}*"
-  elif [ $n -eq 3 ]; then
-    # not sure what this is for yet.
-    local pattern="$name*"
-  elif [ $n -eq 0 ]; then
+  elif [ "$n" -eq 2 ]; then
+    # could be user/repo or repo/one-more-level
+    pattern="$repo_root/${name_parts[0]}*/${name_parts[1]}*"
+    pattern2="$repo_root/*/${name_parts[0]}*/${name_parts[1]}*"
+  elif [ "$n" -eq 3 ]; then
+    # handle root/user/repo/one-more-level
+    pattern="$repo_root/${name_parts[0]}*/${name_parts[1]}*/${name_parts[2]}*"
+  elif [ "$n" -eq 0 ]; then
     # this is too many options, but it's what the user asked for
-    local pattern="$repo_root/*/*"
+    pattern="$repo_root/*/*"
   fi
 
-  if [ -n "$simulated" ]; then
-    echo "compgen -G with $pattern"
+  local sugs
+  IFS=$'\n' read -ra sugs <<< "$(compgen -G "$pattern")"
+
+  if [ -n "$debugging" ]; then
+    IFS=' ' local suggestions="${sugs[*]}"
+    [ -n "$debugging" ] && echo "[compgen -G with $pattern yields $suggestions]"
   fi
 
-  local IFS=$'\n'
-  local sugs=($(compgen -G "$pattern"))
 
   COMPREPLY=()
 
-  for s in "${sugs[@]}"
-  do
+  for s in "${sugs[@]}"; do
     if [ "$user_only" = "true" ]; then
-      COMPREPLY+=($s)
+      COMPREPLY+=("$s")
     else
-      local IFS=$'/'
-      local sug=($(echo "$s"))
-      local IFS=$''
+      IFS="/" read -ra sug <<< "$s"
+      [ -z "$debugging" ] && echo "[$s yields sug" "${sug[@]}" "]"
       local tail="${sug[-2]}/${sug[-1]}"
-      COMPREPLY+=($tail)
+      # if 3 parts were specified, put the first one back in
+      if [ "$n" -eq 3 ]; then
+        tail="${sug[-3]}/$tail"
+      fi
+      COMPREPLY+=("$tail")
     fi
   done
 
   # if there were no suggestions, check to see if it could be a user
-  if [ "${#sugs[@]}" -eq 0 -a "$pattern2" != "" ]; then
-    local sugs=($(compgen -G "$pattern2"))
-    COMPREPLY+=($sugs)
+  if [ "${#sugs[@]}" -eq 0 ] && [ "$pattern2" != "" ]; then
+    [ -n "$debugging" ] && echo "[executing compgen -G $pattern2]"
+    local sugs
+    IFS=$'\n' read -ra sugs <<< "$(compgen -G "$pattern2")"
+    COMPREPLY+=("${sugs[@]}")
   fi
 
-  if [ -n "$simulated" ]; then
-    echo "pretending to goto: ${COMPREPLY[@]}"
+  if [ -n "$debugging" ]; then
+    echo "[pretending to goto:" "${COMPREPLY[@]}" "]"
   fi
 
 }

--- a/goto-completions.sh
+++ b/goto-completions.sh
@@ -96,7 +96,7 @@ _goto_completions()
       COMPREPLY+=("$s")
     else
       IFS="/" read -ra sug <<< "$s"
-      [ -z "$debugging" ] && echo "[$s yields sug" "${sug[@]}" "]"
+      [ -n "$debugging" ] && echo "[$s yields sug" "${sug[@]}" "]"
       local tail="${sug[-2]}/${sug[-1]}"
       # if 3 parts were specified, put the first one back in
       if [ "$n" -eq 3 ]; then

--- a/readme.md
+++ b/readme.md
@@ -10,14 +10,14 @@ my github repositories in a similar structure, e.g.,
 ```bash
 ~/
   github.com/
-  bmacnaughton/
-    goto-repo/
-    testeachversion/
-    ws/
-  mochajs/
-    mocha
-  websockets/
-    ws
+    bmacnaughton/
+      goto-repo/
+      testeachversion/
+      ws/
+    mochajs/
+      mocha
+    websockets/
+      ws
 ```
 
 i wanted a simple way to specify just the target and be able to navigate to
@@ -37,6 +37,9 @@ using bash editing you'd hit alt-b, insert `b/`, ctrl-e to get to the end of
 the line, then hit tab again and you'll get the unique completion
 `bmacnaughton/ws`.
 
+if the argument doesn't match a repo and does match a username in the root,
+then `goto` will go to `$HOME/github.com/username`.
+
 ### installing
 
 if you've got this repo cloned into an environment like shown above then add
@@ -53,9 +56,7 @@ i wanted to implement bash completion and chose this. there are a few things
 i'd like to fix but it works well enough until i have time to fiddle with it
 some more.
 
-- consider putting the logic into the `goto` function
-- if only one arg, and it's not found, try it as username, not repo name.
-
+- nothing on the list right now
 ### bcompare-completions
 
 i use bcompare and just added a simple completer for it. it's got nothing to


### PR DESCRIPTION
- update per shellcheck issues
- allow 2 element paths to match repo/one-more-level if no match for user/repo
- 3 element paths now match user/repo/one-more-level